### PR TITLE
feat: Implement Dashboard UI enhancements

### DIFF
--- a/client/src/components/dashboard/RecentAssetsWidget.tsx
+++ b/client/src/components/dashboard/RecentAssetsWidget.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Link } from 'wouter';
+
+// Matching the interface from DashboardPage.tsx
+interface RecentAsset {
+  id: number;
+  name: string;
+  type: string;
+  ipAddress: string;
+  createdAt: string; // Available, can be used for display if desired (e.g., "Added on X")
+}
+
+interface RecentAssetsWidgetProps {
+  assets: RecentAsset[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+const RecentAssetsWidget: React.FC<RecentAssetsWidgetProps> = ({ assets, isLoading, error }) => {
+  return (
+    <div className="bg-white shadow-lg rounded-xl p-6">
+      <h3 className="text-xl font-semibold text-gray-800 mb-4">Recently Added Assets</h3>
+      {isLoading && <p className="text-gray-500">Loading recent assets...</p>}
+      {error && <p className="text-red-500">Error: {error}</p>}
+      {!isLoading && !error && (
+        assets.length === 0 ? (
+          <p className="text-gray-500">No recent assets found.</p>
+        ) : (
+          <ul className="space-y-3">
+            {assets.map(asset => (
+              <li key={asset.id} className="p-3 bg-gray-50 hover:bg-gray-100 rounded-md transition-colors">
+                <div className="flex justify-between items-center">
+                  <div>
+                    <Link href={`/assets`} className="text-indigo-600 hover:text-indigo-800 font-medium">
+                      {asset.name}
+                    </Link>
+                    <p className="text-xs text-gray-500">
+                      Added: {new Date(asset.createdAt).toLocaleDateString()}
+                    </p>
+                  </div>
+                  <div className="text-right">
+                     <p className="text-sm text-gray-700">{asset.type}</p>
+                     <p className="text-xs text-gray-500">{asset.ipAddress}</p>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )
+      )}
+    </div>
+  );
+};
+
+export default RecentAssetsWidget;

--- a/client/src/components/dashboard/RecentVulnerabilitiesWidget.tsx
+++ b/client/src/components/dashboard/RecentVulnerabilitiesWidget.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Link } from 'wouter';
+
+// Matching the interface from DashboardPage.tsx
+interface RecentVulnerabilityInstance {
+  joinId: number; // ID from the assets_vulnerabilities join table
+  vulnerabilityName: string;
+  vulnerabilitySeverity: string;
+  assetName: string;
+  assetIpAddress: string; // Available if needed, not explicitly requested for display here
+  lastSeenOrUpdatedAt: string;
+  // assetId is not directly in this flat structure from backend,
+  // but assetName implies an asset. Link will go to general /assets for now.
+}
+
+interface RecentVulnerabilitiesWidgetProps {
+  vulnerabilities: RecentVulnerabilityInstance[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+const severityColorMap: { [key: string]: string } = {
+  critical: 'text-red-600',
+  high: 'text-orange-500',
+  medium: 'text-yellow-600',
+  low: 'text-blue-500',
+  informational: 'text-gray-500',
+};
+
+const RecentVulnerabilitiesWidget: React.FC<RecentVulnerabilitiesWidgetProps> = ({
+  vulnerabilities,
+  isLoading,
+  error,
+}) => {
+  return (
+    <div className="bg-white shadow-lg rounded-xl p-6">
+      <h3 className="text-xl font-semibold text-gray-800 mb-4">Recently Active Vulnerabilities</h3>
+      {isLoading && <p className="text-gray-500">Loading recent vulnerabilities...</p>}
+      {error && <p className="text-red-500">Error: {error}</p>}
+      {!isLoading && !error && (
+        vulnerabilities.length === 0 ? (
+          <p className="text-gray-500">No recently active open vulnerabilities found.</p>
+        ) : (
+          <ul className="space-y-3">
+            {vulnerabilities.map(vuln => (
+              <li key={vuln.joinId} className="p-3 bg-gray-50 hover:bg-gray-100 rounded-md transition-colors">
+                <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start">
+                  <div className="mb-2 sm:mb-0">
+                    <p className="text-sm font-medium text-gray-900">{vuln.vulnerabilityName}</p>
+                    <p className={`text-xs font-semibold ${severityColorMap[vuln.vulnerabilitySeverity?.toLowerCase()] || 'text-gray-600'}`}>
+                      Severity: {vuln.vulnerabilitySeverity || 'N/A'}
+                    </p>
+                  </div>
+                  <div className="text-sm text-gray-600 sm:text-right">
+                    <p>
+                      On Asset: <Link href="/assets" className="text-indigo-600 hover:text-indigo-800">{vuln.assetName}</Link>
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      Last Active: {new Date(vuln.lastSeenOrUpdatedAt).toLocaleDateString()}
+                    </p>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )
+      )}
+    </div>
+  );
+};
+
+export default RecentVulnerabilitiesWidget;

--- a/client/src/components/dashboard/StatCard.tsx
+++ b/client/src/components/dashboard/StatCard.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+interface StatCardProps {
+  title: string;
+  value: string | number;
+  icon?: React.ReactNode;
+  className?: string;
+  valueClassName?: string; // For specific styling of the value
+  titleClassName?: string; // For specific styling of the title
+}
+
+const StatCard: React.FC<StatCardProps> = ({ 
+  title, 
+  value, 
+  icon, 
+  className = '',
+  valueClassName = 'text-3xl font-bold text-gray-800',
+  titleClassName = 'text-sm font-medium text-gray-500 truncate'
+}) => {
+  return (
+    <div className={`bg-white shadow-lg rounded-xl p-5 ${className}`}>
+      <div className="flex items-center space-x-4">
+        {icon && <div className="flex-shrink-0">{icon}</div>}
+        <div className="flex-1 min-w-0">
+          <p className={titleClassName}>
+            {title}
+          </p>
+          <p className={valueClassName}>
+            {value}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default StatCard;

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,11 +1,176 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import StatCard from '../../components/dashboard/StatCard';
+import RecentAssetsWidget from '../../components/dashboard/RecentAssetsWidget';
+import RecentVulnerabilitiesWidget from '../../components/dashboard/RecentVulnerabilitiesWidget'; // Import RecentVulnerabilitiesWidget
 
-function Dashboard() {
-  return (
-    <div>
-      <h2>Dashboard Page</h2>
-    </div>
-  );
+// Define Data Structures (assuming these are already here from previous step)
+interface StatisticsData {
+  totalAssets: number;
+  totalVulnerabilities: number;
+  totalOpenVulnerabilityInstances: number;
+  openVulnerabilitiesBySeverity: {
+    critical: number;
+    high: number;
+    medium: number;
+    low: number;
+    informational: number;
+  };
 }
 
-export default Dashboard;
+interface RecentAsset {
+  id: number;
+  name: string;
+  type: string;
+  ipAddress: string;
+  createdAt: string;
+}
+
+interface RecentVulnerabilityInstance {
+  joinId: number;
+  vulnerabilityName: string;
+  vulnerabilitySeverity: string;
+  assetName: string;
+  assetIpAddress: string;
+  lastSeenOrUpdatedAt: string;
+}
+
+const DashboardPage: React.FC = () => {
+  const { isAuthenticated, isLoading: authIsLoading } = useAuth();
+
+  // 2. State Management
+  const [statsData, setStatsData] = useState<StatisticsData | null>(null);
+  const [recentAssets, setRecentAssets] = useState<RecentAsset[]>([]);
+  const [recentVulns, setRecentVulns] = useState<RecentVulnerabilityInstance[]>([]);
+
+  const [isStatsLoading, setIsStatsLoading] = useState<boolean>(true);
+  const [isRecentAssetsLoading, setIsRecentAssetsLoading] = useState<boolean>(true);
+  const [isRecentVulnsLoading, setIsRecentVulnsLoading] = useState<boolean>(true);
+
+  const [statsError, setStatsError] = useState<string | null>(null);
+  const [recentAssetsError, setRecentAssetsError] = useState<string | null>(null);
+  const [recentVulnsError, setRecentVulnsError] = useState<string | null>(null);
+
+  // 3. Data Fetching
+  useEffect(() => {
+    if (!isAuthenticated || authIsLoading) {
+      if (!authIsLoading && !isAuthenticated) {
+        // Clear data or show message if unauthenticated after auth check
+        setIsStatsLoading(false);
+        setIsRecentAssetsLoading(false);
+        setIsRecentVulnsLoading(false);
+      }
+      return;
+    }
+
+    const fetchData = async (
+      url: string, 
+      setData: React.Dispatch<React.SetStateAction<any>>, 
+      setLoading: React.Dispatch<React.SetStateAction<boolean>>, 
+      setError: React.Dispatch<React.SetStateAction<string | null>>
+    ) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch(url);
+        if (!response.ok) {
+          const errorData = await response.json();
+          throw new Error(errorData.message || `Error fetching ${url}`);
+        }
+        const data = await response.json();
+        setData(data);
+      } catch (err: any) {
+        setError(err.message || `An unexpected error occurred fetching ${url}`);
+        setData(url.includes('statistics') ? null : []); // Reset to appropriate empty state
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData('/api/dashboard/statistics', setStatsData, setIsStatsLoading, setStatsError);
+    fetchData('/api/dashboard/recent-assets', setRecentAssets, setIsRecentAssetsLoading, setRecentAssetsError);
+    fetchData('/api/dashboard/recent-vulnerabilities', setRecentVulns, setIsRecentVulnsLoading, setRecentVulnsError);
+
+  }, [isAuthenticated, authIsLoading]);
+
+  // 4. Initial Display (Placeholders)
+  if (authIsLoading) {
+    return <div className="p-6 text-center">Loading authentication status...</div>;
+  }
+
+  if (!isAuthenticated) {
+    // This should ideally be handled by ProtectedRoute redirecting to login
+    return <div className="p-6 text-center">Please log in to view the dashboard.</div>;
+  }
+
+  return (
+    <div className="p-6 space-y-8">
+      <h1 className="text-3xl font-bold text-gray-800">Dashboard</h1>
+
+      {/* Statistics Section */}
+      <section>
+        <h2 className="text-2xl font-semibold text-gray-700 mb-3">Statistics</h2>
+        {isStatsLoading ? (
+          <p>Loading statistics...</p>
+        ) : statsError ? (
+          <p className="text-red-500">Error loading statistics: {statsError}</p>
+        ) : statsData ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+            <StatCard title="Total Assets" value={statsData.totalAssets} />
+            <StatCard title="Total Unique Vulnerabilities" value={statsData.totalVulnerabilities} />
+            <StatCard title="Open Vulnerability Instances" value={statsData.totalOpenVulnerabilityInstances} />
+          </div>
+        ) : (
+          <p>No statistics data available.</p>
+        )}
+      </section>
+      
+      {/* Open Vulnerabilities by Severity Section */}
+      {!isStatsLoading && !statsError && statsData && (
+        <section>
+          <h2 className="text-2xl font-semibold text-gray-700 mb-3">Open Vulnerabilities by Severity</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+            {(['critical', 'high', 'medium', 'low', 'informational'] as const).map((severity) => (
+              <StatCard
+                key={severity}
+                title={severity.charAt(0).toUpperCase() + severity.slice(1)}
+                value={statsData.openVulnerabilitiesBySeverity[severity] !== undefined ? statsData.openVulnerabilitiesBySeverity[severity] : 'N/A'}
+                // Optional: Add specific styling or icons based on severity
+                valueClassName={`text-2xl font-bold ${
+                  severity === 'critical' ? 'text-red-600' :
+                  severity === 'high' ? 'text-orange-500' :
+                  severity === 'medium' ? 'text-yellow-500' :
+                  severity === 'low' ? 'text-blue-500' : 
+                  'text-gray-700' // informational
+                }`}
+                titleClassName="text-sm font-medium text-gray-600"
+                className="text-center" // Center text within these smaller cards
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Container for Recent Assets and Recent Vulnerabilities Widgets */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        <section> {/* Recent Assets Section */}
+          <RecentAssetsWidget 
+            assets={recentAssets}
+            isLoading={isRecentAssetsLoading}
+            error={recentAssetsError}
+          />
+        </section>
+
+        <section> {/* Recent Vulnerabilities Section */}
+          <RecentVulnerabilitiesWidget
+            vulnerabilities={recentVulns}
+            isLoading={isRecentVulnsLoading}
+            error={recentVulnsError}
+          />
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default DashboardPage;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3,6 +3,7 @@ import express, { Router, Request, Response } from 'express';
 import authRouter from './auth'; // Import the authentication router
 import assetsRouter from './assets'; // Import the assets router
 import vulnerabilitiesRouter from './vulnerabilities'; // Import the vulnerabilities router
+import dashboardRouter from './dashboard'; // Import the dashboard router
 
 const router: Router = express.Router();
 
@@ -14,6 +15,9 @@ router.use('/assets', assetsRouter);
 
 // Mount vulnerabilities routes
 router.use('/vulnerabilities', vulnerabilitiesRouter);
+
+// Mount dashboard routes
+router.use('/dashboard', dashboardRouter);
 
 // Example API route
 router.get('/hello', (req: Request, res: Response) => {

--- a/server/routes/dashboard.ts
+++ b/server/routes/dashboard.ts
@@ -1,0 +1,128 @@
+import { Router, Request, Response } from 'express';
+import { db } from '../db';
+import { 
+    assets as assetsTable, 
+    vulnerabilities as vulnerabilitiesTable,
+    assets_vulnerabilities as assetVulnerabilitiesTable,
+    vulnerabilitySeverityEnum
+} from '@shared/schema';
+import { count, eq, desc } from 'drizzle-orm'; // Added desc
+import { isAuthenticated } from '../middleware/authMiddleware';
+
+const router = Router();
+
+// Apply isAuthenticated middleware to all routes in this router
+router.use(isAuthenticated);
+
+router.get('/statistics', async (req: Request, res: Response) => {
+  try {
+    // 1. Total number of assets
+    const totalAssetsResult = await db.select({ value: count() }).from(assetsTable);
+    const totalAssets = totalAssetsResult[0]?.value || 0;
+
+    // 2. Total number of unique vulnerabilities
+    const totalVulnerabilitiesResult = await db.select({ value: count() }).from(vulnerabilitiesTable);
+    const totalVulnerabilities = totalVulnerabilitiesResult[0]?.value || 0;
+
+    // 3. Total number of 'open' vulnerability instances
+    const totalOpenInstancesResult = await db
+      .select({ value: count() })
+      .from(assetVulnerabilitiesTable)
+      .where(eq(assetVulnerabilitiesTable.status, 'open'));
+    const totalOpenVulnerabilityInstances = totalOpenInstancesResult[0]?.value || 0;
+
+    // 4. Counts of 'open' vulnerability instances grouped by severity
+    const openBySeverityResult = await db
+      .select({
+        severity: vulnerabilitiesTable.severity,
+        count: count(vulnerabilitiesTable.severity), // Count occurrences of each severity
+      })
+      .from(assetVulnerabilitiesTable)
+      .leftJoin(vulnerabilitiesTable, eq(assetVulnerabilitiesTable.vulnerabilityId, vulnerabilitiesTable.id))
+      .where(eq(assetVulnerabilitiesTable.status, 'open'))
+      .groupBy(vulnerabilitiesTable.severity);
+
+    // Initialize all severity counts to 0
+    const openVulnerabilitiesBySeverity = vulnerabilitySeverityEnum.enumValues.reduce((acc, severityValue) => {
+        acc[severityValue] = 0;
+        return acc;
+    }, {} as Record<typeof vulnerabilitySeverityEnum.enumValues[number], number>);
+    
+    // Populate counts from the query result
+    openBySeverityResult.forEach(row => {
+      if (row.severity) { // Check if severity is not null (it shouldn't be based on schema)
+        openVulnerabilitiesBySeverity[row.severity] = Number(row.count); // Drizzle count returns BigInt or string sometimes
+      }
+    });
+
+    res.status(200).json({
+      totalAssets,
+      totalVulnerabilities,
+      totalOpenVulnerabilityInstances,
+      openVulnerabilitiesBySeverity,
+    });
+
+  } catch (error) {
+    console.error('Error fetching dashboard statistics:', error);
+    res.status(500).json({ message: 'Internal server error while fetching dashboard statistics.' });
+  }
+});
+
+// GET /api/dashboard/recent-vulnerabilities - Fetch 5 most recently active 'open' vulnerability instances
+router.get('/recent-vulnerabilities', async (req: Request, res: Response) => {
+  try {
+    const recentVulnerabilityInstances = await db
+      .select({
+        joinId: assetVulnerabilitiesTable.id,
+        vulnerabilityName: vulnerabilitiesTable.name,
+        vulnerabilitySeverity: vulnerabilitiesTable.severity,
+        assetName: assetsTable.name,
+        assetIpAddress: assetsTable.ipAddress,
+        lastSeenOrUpdatedAt: assetVulnerabilitiesTable.updatedAt, // Using updatedAt from the join table
+      })
+      .from(assetVulnerabilitiesTable)
+      .leftJoin(vulnerabilitiesTable, eq(assetVulnerabilitiesTable.vulnerabilityId, vulnerabilitiesTable.id))
+      .leftJoin(assetsTable, eq(assetVulnerabilitiesTable.assetId, assetsTable.id))
+      .where(eq(assetVulnerabilitiesTable.status, 'open'))
+      .orderBy(desc(assetVulnerabilitiesTable.updatedAt))
+      .limit(5);
+
+    // Ensure that if a vulnerability or asset was somehow deleted but the link record still exists (should not happen with FKs),
+    // we don't return nulls for their direct properties. The leftJoin handles this by returning null for those fields.
+    // The query selects direct fields, so if the join fails to find a match, those fields would be null.
+    // Filter out results where essential joined data might be missing if necessary, although FK constraints should prevent this.
+    const result = recentVulnerabilityInstances.filter(
+        item => item.vulnerabilityName && item.assetName 
+    );
+
+
+    res.status(200).json(result);
+  } catch (error) {
+    console.error('Error fetching recent vulnerability instances:', error);
+    res.status(500).json({ message: 'Internal server error while fetching recent vulnerability instances.' });
+  }
+});
+
+// GET /api/dashboard/recent-assets - Fetch 5 most recently added assets
+router.get('/recent-assets', async (req: Request, res: Response) => {
+  try {
+    const recentAssets = await db
+      .select({
+        id: assetsTable.id,
+        name: assetsTable.name,
+        type: assetsTable.type,
+        ipAddress: assetsTable.ipAddress,
+        createdAt: assetsTable.createdAt,
+      })
+      .from(assetsTable)
+      .orderBy(desc(assetsTable.createdAt))
+      .limit(5);
+
+    res.status(200).json(recentAssets);
+  } catch (error) {
+    console.error('Error fetching recent assets:', error);
+    res.status(500).json({ message: 'Internal server error while fetching recent assets.' });
+  }
+});
+
+export default router;

--- a/server/tests/dashboard.test.ts
+++ b/server/tests/dashboard.test.ts
@@ -1,0 +1,224 @@
+import request from 'supertest';
+import app from '../index'; // The Express app instance
+import { db } from '../db';   // Drizzle ORM instance
+import { 
+    users, 
+    assets as assetsTable, 
+    vulnerabilities as vulnerabilitiesTable,
+    assets_vulnerabilities as assetVulnerabilitiesTable,
+    assetTypeEnum,
+    vulnerabilitySeverityEnum,
+    vulnerabilityStatusEnum
+} from '@shared/schema';
+import { eq, and, desc, sql } from 'drizzle-orm';
+
+let agent: request.SuperAgentTest;
+let testUserId: number;
+
+const baseTestUser = {
+  username: `dashboard_testuser_${Date.now()}`,
+  email: `dashboard_test_${Date.now()}@example.com`,
+  password: 'PasswordSecure123!',
+};
+
+// Helper to introduce slight time differences for ordering tests
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+const createAsset = async (assetData: Partial<typeof assetsTable.$inferInsert>) => {
+  return db.insert(assetsTable).values(assetData as any).returning();
+};
+
+const createVulnerability = async (vulnData: Partial<typeof vulnerabilitiesTable.$inferInsert>) => {
+  return db.insert(vulnerabilitiesTable).values(vulnData as any).returning();
+};
+
+const linkAssetVulnerability = async (linkData: Partial<typeof assetVulnerabilitiesTable.$inferInsert>) => {
+  return db.insert(assetVulnerabilitiesTable).values(linkData as any).returning();
+};
+
+
+describe('Dashboard API (/api/dashboard)', () => {
+  const createdAssetIds: number[] = [];
+  const createdVulnerabilityIds: number[] = [];
+  const createdLinkIds: number[] = [];
+
+  beforeAll(async () => {
+    const registerResponse = await request(app).post('/api/auth/register').send(baseTestUser);
+    if (registerResponse.status !== 201 && registerResponse.status !== 409) {
+      console.error('Test user registration failed for dashboard tests:', registerResponse.body);
+      throw new Error('Failed to register test user for dashboard tests.');
+    }
+    testUserId = registerResponse.status === 201 ? registerResponse.body.user.id : (await db.query.users.findFirst({ where: eq(users.username, baseTestUser.username) }))!.id;
+
+    agent = request.agent(app);
+    const loginResponse = await agent.post('/api/auth/login').send({ username: baseTestUser.username, password: baseTestUser.password });
+    if (loginResponse.status !== 200) {
+      console.error("Login failed for dashboard test user:", loginResponse.body);
+      throw new Error('Login failed for test user in beforeAll for dashboard tests.');
+    }
+  });
+
+  afterEach(async () => {
+    // Clean up any links first due to foreign key constraints
+    if (createdLinkIds.length > 0) {
+      await db.delete(assetVulnerabilitiesTable).where(sql`${assetVulnerabilitiesTable.id} IN ${createdLinkIds}`);
+      createdLinkIds.length = 0; // Clear the array
+    }
+    if (createdAssetIds.length > 0) {
+      await db.delete(assetsTable).where(sql`${assetsTable.id} IN ${createdAssetIds}`);
+      createdAssetIds.length = 0;
+    }
+    if (createdVulnerabilityIds.length > 0) {
+      await db.delete(vulnerabilitiesTable).where(sql`${vulnerabilitiesTable.id} IN ${createdVulnerabilityIds}`);
+      createdVulnerabilityIds.length = 0;
+    }
+  });
+
+  afterAll(async () => {
+    // Fallback cleanup just in case afterEach missed something or for data not tracked in arrays
+    await db.delete(users).where(eq(users.id, testUserId));
+    // Add more cleanup if test data uses very specific naming patterns not covered by afterEach
+  });
+
+  describe('/api/dashboard/statistics', () => {
+    it('should return 401 if not authenticated', async () => {
+      await request(app).get('/api/dashboard/statistics').expect(401);
+    });
+
+    it('should return correct statistics structure and basic counts', async () => {
+      // Setup: 2 assets, 3 vulnerabilities, 2 open links (1 critical, 1 high), 1 remediated link
+      const asset1 = (await createAsset({ name: 'StatAsset1', type: 'server', ipAddress: '1.1.1.1' }))[0];
+      createdAssetIds.push(asset1.id);
+      const asset2 = (await createAsset({ name: 'StatAsset2', type: 'workstation', ipAddress: '2.2.2.2' }))[0];
+      createdAssetIds.push(asset2.id);
+
+      const vuln1 = (await createVulnerability({ name: 'StatVulnC', description: 'd', severity: 'critical' }))[0];
+      createdVulnerabilityIds.push(vuln1.id);
+      const vuln2 = (await createVulnerability({ name: 'StatVulnH', description: 'd', severity: 'high' }))[0];
+      createdVulnerabilityIds.push(vuln2.id);
+      const vuln3 = (await createVulnerability({ name: 'StatVulnM', description: 'd', severity: 'medium' }))[0];
+      createdVulnerabilityIds.push(vuln3.id);
+
+      const link1 = (await linkAssetVulnerability({ assetId: asset1.id, vulnerabilityId: vuln1.id, status: 'open' }))[0];
+      createdLinkIds.push(link1.id);
+      const link2 = (await linkAssetVulnerability({ assetId: asset2.id, vulnerabilityId: vuln2.id, status: 'open' }))[0];
+      createdLinkIds.push(link2.id);
+      const link3 = (await linkAssetVulnerability({ assetId: asset1.id, vulnerabilityId: vuln3.id, status: 'remediated' }))[0];
+      createdLinkIds.push(link3.id);
+      
+      const response = await agent.get('/api/dashboard/statistics').expect(200);
+      
+      expect(response.body).toHaveProperty('totalAssets');
+      expect(response.body).toHaveProperty('totalVulnerabilities');
+      expect(response.body).toHaveProperty('totalOpenVulnerabilityInstances');
+      expect(response.body).toHaveProperty('openVulnerabilitiesBySeverity');
+      
+      // Basic count verification - these will be affected by other tests if not perfectly isolated.
+      // For more precise count checks in a shared DB env, query counts before and after test-specific setup.
+      // This test assumes a relatively clean state for these specific items or that global count doesn't matter as much as structure.
+      // For this example, we'll check against the items created *within this test*.
+      // This requires re-querying the DB for totals if we want to be exact, or ensuring the test DB is truly empty.
+      // The current implementation in dashboard.ts queries ALL assets/vulns. So we can only check if our additions impacted it.
+      
+      expect(response.body.totalOpenVulnerabilityInstances).toBeGreaterThanOrEqual(2);
+      expect(response.body.openVulnerabilitiesBySeverity.critical).toBeGreaterThanOrEqual(1);
+      expect(response.body.openVulnerabilitiesBySeverity.high).toBeGreaterThanOrEqual(1);
+      expect(response.body.openVulnerabilitiesBySeverity.medium).toBeGreaterThanOrEqual(0); // could be 0 if only remediated one exists
+      expect(response.body.openVulnerabilitiesBySeverity.low).toBeGreaterThanOrEqual(0);
+      expect(response.body.openVulnerabilitiesBySeverity.informational).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('/api/dashboard/recent-assets', () => {
+    it('should return 401 if not authenticated', async () => {
+      await request(app).get('/api/dashboard/recent-assets').expect(401);
+    });
+
+    it('should return up to 5 most recent assets, ordered by createdAt descending', async () => {
+      for (let i = 0; i < 7; i++) {
+        const asset = (await createAsset({ 
+            name: `RecentAsset${i}`, 
+            type: 'server', 
+            ipAddress: `1.2.3.${i}`,
+            createdAt: new Date() // Drizzle defaultNow() will handle this, but explicit for test control
+        }))[0];
+        createdAssetIds.push(asset.id);
+        if (i < 6) await sleep(10); // Ensure slight time difference for ordering
+      }
+
+      const response = await agent.get('/api/dashboard/recent-assets').expect(200);
+      expect(Array.isArray(response.body)).toBe(true);
+      expect(response.body.length).toBeLessThanOrEqual(5);
+      if (response.body.length > 1) {
+        const firstDate = new Date(response.body[0].createdAt).getTime();
+        const secondDate = new Date(response.body[1].createdAt).getTime();
+        expect(firstDate).toBeGreaterThanOrEqual(secondDate);
+      }
+      response.body.forEach((asset: any) => {
+        expect(asset).toHaveProperty('id');
+        expect(asset).toHaveProperty('name');
+        expect(asset).toHaveProperty('type');
+        expect(asset).toHaveProperty('ipAddress');
+        expect(asset).toHaveProperty('createdAt');
+      });
+      // Check if the most recent one (RecentAsset6) is present
+      expect(response.body.some((a: any) => a.name === "RecentAsset6")).toBe(true);
+    });
+  });
+
+  describe('/api/dashboard/recent-vulnerabilities', () => {
+    it('should return 401 if not authenticated', async () => {
+      await request(app).get('/api/dashboard/recent-vulnerabilities').expect(401);
+    });
+
+    it('should return up to 5 most recent "open" vulnerability instances, ordered by link updatedAt descending', async () => {
+      const assetA = (await createAsset({ name: 'VulnLinkAssetA', type: 'server', ipAddress: '4.3.2.1' }))[0];
+      createdAssetIds.push(assetA.id);
+      const assetB = (await createAsset({ name: 'VulnLinkAssetB', type: 'workstation', ipAddress: '4.3.2.2' }))[0];
+      createdAssetIds.push(assetB.id);
+
+      const vulnX = (await createVulnerability({ name: 'VulnLinkX', description: 'dx', severity: 'critical' }))[0];
+      createdVulnerabilityIds.push(vulnX.id);
+      const vulnY = (await createVulnerability({ name: 'VulnLinkY', description: 'dy', severity: 'high' }))[0];
+      createdVulnerabilityIds.push(vulnY.id);
+      const vulnZ = (await createVulnerability({ name: 'VulnLinkZ', description: 'dz', severity: 'medium' }))[0];
+      createdVulnerabilityIds.push(vulnZ.id);
+
+      // Create 7 links, some open, some not, with varying updatedAt (implicitly by creation order + sleep)
+      for (let i = 0; i < 7; i++) {
+        const link = (await linkAssetVulnerability({
+          assetId: i % 2 === 0 ? assetA.id : assetB.id,
+          vulnerabilityId: [vulnX.id, vulnY.id, vulnZ.id][i % 3],
+          status: i < 5 ? 'open' : 'remediated', // First 5 are open
+          // updatedAt is handled by defaultNow() and $onUpdate
+          // lastSeenAt also defaults to now
+        }))[0];
+        createdLinkIds.push(link.id);
+        if (i < 6) await sleep(10); // Ensure slight time difference for ordering
+      }
+      
+      const response = await agent.get('/api/dashboard/recent-vulnerabilities').expect(200);
+      expect(Array.isArray(response.body)).toBe(true);
+      expect(response.body.length).toBeLessThanOrEqual(5);
+      
+      let lastUpdatedAt = Infinity;
+      response.body.forEach((item: any) => {
+        expect(item).toHaveProperty('joinId');
+        expect(item).toHaveProperty('vulnerabilityName');
+        expect(item).toHaveProperty('vulnerabilitySeverity');
+        expect(item).toHaveProperty('assetName');
+        expect(item).toHaveProperty('assetIpAddress');
+        expect(item).toHaveProperty('lastSeenOrUpdatedAt');
+        // Assuming the backend returns status, but it's filtered to 'open'
+        // expect(item.status).toBe('open'); // This is implicit in the backend logic
+
+        const currentUpdatedAt = new Date(item.lastSeenOrUpdatedAt).getTime();
+        expect(currentUpdatedAt).toBeLessThanOrEqual(lastUpdatedAt);
+        lastUpdatedAt = currentUpdatedAt;
+      });
+      // Ensure only 'open' vulnerabilities were considered (difficult to directly test without knowing which ones were 'open' and their exact timestamps)
+      // The backend query filters for 'open'. If less than 5 'open' exist, it will return less than 5.
+      // If more than 5 'open' exist, it will return the 5 most recent by link's updatedAt.
+    });
+  });
+});


### PR DESCRIPTION
This commit introduces a revamped Dashboard page with dynamic data display, providing you with an overview of assets and vulnerabilities.

Backend:
- Created `server/routes/dashboard.ts` with new API endpoints:
    - `GET /api/dashboard/statistics`: Provides aggregate statistics (total assets, total vulnerabilities, open vulnerability instances, counts by severity).
    - `GET /api/dashboard/recent-assets`: Returns the 5 most recently added assets.
    - `GET /api/dashboard/recent-vulnerabilities`: Returns the 5 most recently active 'open' vulnerability instances.
- All dashboard API endpoints are authenticated.
- Added backend integration tests in `server/tests/dashboard.test.ts` for these new endpoints using Jest and Supertest.

Frontend:
- Updated `client/src/pages/Dashboard.tsx`:
    - Fetches data from the new dashboard API endpoints.
    - Manages loading and error states for these calls.
- Implemented display widgets:
    - `StatCard.tsx` (reused or created) to display key statistics in a card format.
    - `RecentAssetsWidget.tsx` to list recently added assets with links.
    - `RecentVulnerabilitiesWidget.tsx` to list recently active 'open' vulnerabilities with details and links.
- Styled the Dashboard page using Tailwind CSS for a responsive layout:
    - Statistics are displayed in a grid at the top.
    - Recent assets and recent vulnerabilities widgets are arranged in a two-column layout below statistics (stacks on smaller screens).